### PR TITLE
fix(dsh1024): keep the store bridge alive when init lands before the load event

### DIFF
--- a/plugin/client/client.js
+++ b/plugin/client/client.js
@@ -544,10 +544,18 @@ function MarketShell({ locale, onClose, activation }) {
   }, [connectFrame, embedUrl])
 
   const frameLoaded = useCallback(() => {
-    closeBridge()
-    setConnection('connecting')
-    readyTimerRef.current = window.setTimeout(() => setConnection('failed'), READY_TIMEOUT_MS)
-  }, [closeBridge])
+    // Drive the handshake from the load event instead of only arming the
+    // timeout. In Firefox the embedded page posts its 'init' BEFORE the
+    // iframe's load event fires (init comes from a passive effect, while
+    // load waits for every subresource), so a connectFrame() started by
+    // onFrameInit used to be clobbered here by closeBridge(), leaving a
+    // dead bridge that failed after the timeout. connectFrame() is
+    // idempotent (it closeBridge()es first) and the storefront answers
+    // 'connect' whenever it arrives, so calling it here is safe whether
+    // init already came, comes later, or never comes.
+    if (portRef.current !== null) return
+    connectFrame()
+  }, [connectFrame])
 
   const reloadFrame = useCallback(() => {
     closeBridge()


### PR DESCRIPTION
Port of the approach from #8 (old-repo PR imsai-sh/awesome-deepseek-harness-plugins#239), resubmitted after the repository split, with one addition.

## Problem

In Firefox the storefront posts its bridge `init` before the iframe `load` event fires (init comes from a React passive effect, while `load` waits for every subresource), so `connectFrame()` completes the handshake and the later `load` then runs `closeBridge()` on the live port. The 5s timeout then flips the panel to the fallback. With a warm CDN cache this fails on every open.

## Fix

`frameLoaded` no longer tears down a live bridge, and starts the handshake itself when none exists:

```js
const frameLoaded = useCallback(() => {
  if (portRef.current !== null) return
  connectFrame()
}, [connectFrame])
```

`connectFrame()` is idempotent (it calls `closeBridge()` first) and the storefront answers `connect` whenever it arrives, so this covers both event orders and also recovers when `init` is missed entirely.

## Verification

Tested on dsh1024 0.5.0 / DSH 0.1.2-rc.1 with Firefox as the harness UI browser on Linux: the panel fails on every open before the change and connects on every open after it. Bridge trace in the issue comment on #8.

No API surface touched, so `test:api-contract` is unaffected; happy to run the full `typecheck`/`test`/`build` lane on request.
